### PR TITLE
Disable comparison for new products widget

### DIFF
--- a/Plugin/Magento/Catalog/Block/Product/AbstractProduct.php
+++ b/Plugin/Magento/Catalog/Block/Product/AbstractProduct.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Authors: Alex Gusev <alex@flancer64.com>
+ * Since: 2018
+ */
+
+namespace GalacticLabs\DisableCompareProducts\Plugin\Magento\Catalog\Block\Product;
+
+use GalacticLabs\DisableCompareProducts\Observer\LayoutLoadBefore as AnObserver;
+
+class AbstractProduct
+{
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    public function __construct(
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+    )
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Return 'null' if product comparision is disabled.
+     *
+     * @param \Magento\Catalog\Block\Product\AbstractProduct $subject
+     * @param string $result
+     * @return string|null
+     */
+    public function afterGetAddToCompareUrl(
+        \Magento\Catalog\Block\Product\AbstractProduct $subject,
+        $result
+    ) {
+        $disableCompare = $this->scopeConfig->getValue(AnObserver::DISABLE_COMPARE_CONFIG_PATH);
+
+        if($disableCompare){
+            $result=null;
+        }
+        return $result;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<config
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+
+    <!-- ******* -->
+    <!-- PLUGINS -->
+    <!-- ******* -->
+    <type name="Magento\Catalog\Block\Product\AbstractProduct">
+        <!--Disable product comparison link to prevent products compare link in new products widget. -->
+        <plugin name="galacticlabs_disable_compare_products"
+                type="GalacticLabs\DisableCompareProducts\Plugin\Magento\Catalog\Block\Product\AbstractProduct"
+                sortOrder="100" disabled="false"/>
+    </type>
+
+</config>


### PR DESCRIPTION
I have added plugin to disable products comparison in "New Products" widget:

![image](https://user-images.githubusercontent.com/5052385/40437051-07d74ef4-5ebd-11e8-8e1b-6d6e1cbfa03e.png)


`module-catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml`

```
<?php if ($block->getAddToCompareUrl() && $showCompare): ?>
    ...
<?php endif; ?>
```